### PR TITLE
Make cards responsive and make card more compact along with minor change to Grades table

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -27,6 +27,10 @@ class App extends Component {
 
   componentDidMount() {
     window.addEventListener("resize", this.updateWidth)
+    if (document.getElementById("root").clientWidth < 796) {
+      this.setState({ mobile: true })
+    }
+
     getTerms()
       .then(terms => {
         for (let i = 0, total = terms.length; i < total; i++) {

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react"
 import "./App.css"
-import BasicTabs from "./components/BasicTabs"
+import CoursesTabs from "./components/CoursesTabs"
 import TermsMenu from "./components/TermsMenu"
 import { getTerms, getCourses } from "./api/api"
 
@@ -57,7 +57,6 @@ class App extends Component {
   }
 
   render() {
-    console.log(this.props.theme)
     if (this.state.terms === null) {
       return <div />
     } else {
@@ -68,7 +67,7 @@ class App extends Component {
             currentTermDescription={this.state.currentTermDescription}
             updateTerm={this.updateTerm}
           />
-          <BasicTabs
+          <CoursesTabs
             currentTermCode={this.state.currentTermCode}
             courses={this.state.courses}
             mobile={this.state.mobile}

--- a/src/App.js
+++ b/src/App.js
@@ -9,10 +9,24 @@ class App extends Component {
     terms: null,
     currentTermDescription: "",
     currentTermCode: "",
-    courses: []
+    courses: [],
+    width: document.getElementById("root").clientWidth,
+    mobile: false
+  }
+
+  updateWidth = () => {
+    this.setState({
+      width: document.getElementById("root").clientWidth
+    })
+    if (this.state.width < 796) {
+      this.setState({ mobile: true })
+    } else {
+      this.setState({ mobile: false })
+    }
   }
 
   componentDidMount() {
+    window.addEventListener("resize", this.updateWidth)
     getTerms()
       .then(terms => {
         for (let i = 0, total = terms.length; i < total; i++) {
@@ -44,7 +58,7 @@ class App extends Component {
       return <div />
     } else {
       return (
-        <div style={{ padding: "2em" }}>
+        <div>
           <TermsMenu
             terms={this.state.terms}
             currentTermDescription={this.state.currentTermDescription}
@@ -53,6 +67,7 @@ class App extends Component {
           <BasicTabs
             currentTermCode={this.state.currentTermCode}
             courses={this.state.courses}
+            mobile={this.state.mobile}
           />
         </div>
       )

--- a/src/App.js
+++ b/src/App.js
@@ -34,7 +34,7 @@ class App extends Component {
     getTerms()
       .then(terms => {
         for (let i = 0, total = terms.length; i < total; i++) {
-          if (terms[i].current === "true") {
+          if (Object.is(terms[i].current, "true")) {
             this.setState({
               currentTermDescription: terms[i].description,
               currentTermCode: terms[i].code
@@ -57,7 +57,7 @@ class App extends Component {
   }
 
   render() {
-    if (this.state.terms === null) {
+    if (Object.is(this.state.terms, null)) {
       return <div />
     } else {
       return (
@@ -66,6 +66,7 @@ class App extends Component {
             terms={this.state.terms}
             currentTermDescription={this.state.currentTermDescription}
             updateTerm={this.updateTerm}
+            mobile={this.state.mobile}
           />
           <CoursesTabs
             currentTermCode={this.state.currentTermCode}

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -17,7 +17,6 @@ export const getCourses = async code => {
     const courses = await response.json()
     return courses.courses
   } catch (err) {
-    console.error(err)
     return err
   }
 }

--- a/src/components/BasicTabs.js
+++ b/src/components/BasicTabs.js
@@ -67,6 +67,7 @@ class BasicTabs extends Component {
                 tabIndex="0"
                 currentTermCode={this.props.currentTermCode}
                 courses={this.props.courses}
+                mobile={this.props.mobile}
               />
             </div>
           </TabContainer>}

--- a/src/components/CourseDetails.js
+++ b/src/components/CourseDetails.js
@@ -59,9 +59,9 @@ class CourseDetails extends Component {
             color="accent"
             onClick={this.handleOpen}
             id={"openbutton" + this.props.course.crn}
-            aria-label="more course information"
+            aria-label="course description"
           >
-            {t("courseDetails", {})}
+            {t("description", {})}
           </Button>
 
           <Dialog

--- a/src/components/CourseDetails.js
+++ b/src/components/CourseDetails.js
@@ -26,7 +26,8 @@ const styleSheet = createStyleSheet("CourseDetails", theme => ({
     color: "rgba(0, 0, 0, 0.68)"
   },
 
-  dialogBackground: {
+  dialogContent: {
+    backgroundColor: "#fafafa",
     background: "#E8EAEE"
   },
 
@@ -69,7 +70,7 @@ class CourseDetails extends Component {
           <Dialog
             role="dialog"
             id="dialogbox"
-            aria-label="my courses information"
+            aria-label="course description"
             tabIndex="0"
             open={this.state.open}
             onRequestClose={this.handleClose}
@@ -84,7 +85,7 @@ class CourseDetails extends Component {
               </Typography>
             </DialogTitle>
             <DialogContent
-              className={classes.dialogBackground}
+              className={classes.dialogContent}
               aria-labelledby="dialogbox"
             >
               <List>

--- a/src/components/CourseDetails.js
+++ b/src/components/CourseDetails.js
@@ -9,6 +9,7 @@ import Button from "material-ui/Button"
 import Slide from "material-ui/transitions/Slide"
 import Typography from "material-ui/Typography"
 import { withStyles, createStyleSheet } from "material-ui/styles"
+import PropTypes from "prop-types"
 import { translate, Interpolate } from "react-i18next"
 import i18n from "./../utils/i18n"
 
@@ -50,8 +51,9 @@ class CourseDetails extends Component {
   render() {
     const classes = this.props.classes
     const { t } = this.props
-    if (this.props.courses === null) return <div />
-    else {
+    if (Object.is(this.props.courses, null)) {
+      return <div />
+    } else {
       return (
         <div aria-labelledby={"openbutton" + this.props.course.crn}>
           <Button
@@ -109,6 +111,11 @@ class CourseDetails extends Component {
     }
   }
 }
+
+CourseDetails.propTypes = {
+  classes: PropTypes.object.isRequired
+}
+
 export default withStyles(styleSheet)(
   translate("view", { wait: true })(CourseDetails)
 )

--- a/src/components/CourseDetails.js
+++ b/src/components/CourseDetails.js
@@ -13,6 +13,10 @@ import { translate, Interpolate } from "react-i18next"
 import i18n from "./../utils/i18n"
 
 const styleSheet = createStyleSheet("CourseDetails", theme => ({
+  button: {
+    fontWeight: "bolder"
+  },
+
   dialogHeader: {
     backgroundColor: theme.palette.primary[400]
   },
@@ -51,8 +55,8 @@ class CourseDetails extends Component {
       return (
         <div aria-labelledby={"openbutton" + this.props.course.crn}>
           <Button
-            raised
-            accent
+            className={classes.button}
+            color="accent"
             onClick={this.handleOpen}
             id={"openbutton" + this.props.course.crn}
             aria-label="more course information"
@@ -83,68 +87,17 @@ class CourseDetails extends Component {
             >
               <List>
                 <ListItem tabIndex="0">
-                  <ListItemText
-                    primary={t("courseTitle", {})}
-                    secondary={
-                      <p className={classes.list}>
-                        {this.props.course.courseTitle}
-                      </p>
-                    }
-                  />
-                </ListItem>
-
-                <ListItem tabIndex="0">
-                  <ListItemText
-                    primary={t("crn", {})}
-                    secondary={
-                      <p className={classes.list}>
-                        {this.props.course.crn}
-                      </p>
-                    }
-                  />
-                </ListItem>
-
-                <ListItem tabIndex="0">
-                  <ListItemText
-                    primary={t("department", {})}
-                    secondary={
-                      <p className={classes.list}>
-                        {this.props.course.departmentDescription}
-                      </p>
-                    }
-                  />
-                </ListItem>
-
-                <ListItem tabIndex="0">
-                  <ListItemText
-                    primary={t("grade", {})}
-                    secondary={
-                      <p className={classes.list}>
-                        {this.props.course.grade.grade}
-                      </p>
-                    }
-                  />
-                </ListItem>
-
-                <ListItem tabIndex="0">
-                  <ListItemText
-                    primary={t("description", {})}
-                    secondary={
-                      <p className={classes.list}>
-                        {this.props.course.courseDescription}
-                      </p>
-                    }
-                  />
+                  <ListItemText primary={this.props.course.courseDescription} />
                 </ListItem>
               </List>
 
               <DialogActions>
                 <Button
+                  className={classes.button}
                   onClick={this.handleClose}
                   aria-label="close course information"
                   tabIndex="0"
-                  raised
-                  accent
+                  color="accent"
                 >
                   {t("close", {})}
                 </Button>

--- a/src/components/Courses.js
+++ b/src/components/Courses.js
@@ -162,7 +162,7 @@ class Courses extends Component {
 
   render() {
     const classes = this.props.classes
-    if (this.props.courses === null) {
+    if (Object.is(this.props.courses, null)) {
       return <div />
     } else {
       return (

--- a/src/components/Courses.js
+++ b/src/components/Courses.js
@@ -49,9 +49,19 @@ const styleSheet = createStyleSheet("Courses", theme => ({
     color: theme.palette.text.primary
   },
 
+  infoContainer: {
+    marginLeft: "2em"
+  },
+
   classHeader: {
     height: 65,
     backgroundColor: theme.palette.primary[400]
+  },
+
+  classHeaderMobile: {
+    height: 65,
+    backgroundColor: theme.palette.primary[400],
+    textAlign: "center"
   },
 
   classHeaderSpanDiv: {
@@ -66,6 +76,17 @@ const styleSheet = createStyleSheet("Courses", theme => ({
 
   content: {
     paddingTop: 0
+  },
+
+  contentMobile: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center"
+  },
+
+  actions: {
+    display: "flex",
+    justifyContent: "center"
   }
 }))
 
@@ -89,7 +110,7 @@ class Courses extends Component {
       } else {
         elements.push(
           <div
-            className={this.props.mobile ? classes.courseContainer : ""}
+            className={this.props.mobile ? classes.courseContainer : null}
             key={this.props.courses[i].crn + i + Math.random()}
           >
             <div style={{ marginTop: "1em" }}>
@@ -100,7 +121,11 @@ class Courses extends Component {
                 key={this.props.courses[i].crn + i + Math.random()}
               >
                 <CardHeader
-                  className={classes.classHeader}
+                  className={
+                    this.props.mobile
+                      ? classes.classHeaderMobile
+                      : classes.classHeader
+                  }
                   title={
                     <Typography
                       tabIndex="0"
@@ -130,23 +155,32 @@ class Courses extends Component {
                   }
                 />
                 <CardContent
-                  className={classes.content}
+                  className={
+                    this.props.mobile ? classes.contentMobile : classes.content
+                  }
                   key={this.props.courses[i].crn + i + Math.random()}
                 >
                   <div
-                    style={{ marginTop: "1em" }}
-                    key={this.props.courses[i].crn + i + Math.random()}
+                    className={this.props.mobile ? classes.infoContainer : null}
                   >
-                    <Meetings meetings={this.props.courses[i].meetings} />
-                  </div>
-                  <div
-                    style={{ marginTop: "1em" }}
-                    key={this.props.courses[i].crn + i + Math.random()}
-                  >
-                    <Instructors teachers={this.props.courses[i].instructors} />
+                    <div
+                      style={{ marginTop: "1em" }}
+                      key={this.props.courses[i].crn + i + Math.random()}
+                    >
+                      <Meetings meetings={this.props.courses[i].meetings} />
+                    </div>
+                    <div
+                      style={{ marginTop: "1em" }}
+                      key={this.props.courses[i].crn + i + Math.random()}
+                    >
+                      <Instructors
+                        teachers={this.props.courses[i].instructors}
+                      />
+                    </div>
                   </div>
                 </CardContent>
                 <CardActions
+                  className={this.props.mobile ? classes.actions : null}
                   key={this.props.courses[i].crn + i + Math.random()}
                 >
                   <CourseDetails course={this.props.courses[i]} />

--- a/src/components/Courses.js
+++ b/src/components/Courses.js
@@ -23,6 +23,11 @@ const styleSheet = createStyleSheet("Courses", theme => ({
     backgroundColor: "#fafafa"
   },
 
+  cardMobile: {
+    width: "264px",
+    backgroundColor: "#fafafa"
+  },
+
   courseTitle: {
     fontSize: 16,
     color: theme.palette.text.primary
@@ -48,26 +53,6 @@ const styleSheet = createStyleSheet("Courses", theme => ({
 }))
 
 class Courses extends Component {
-  componentDidMount() {
-    window.addEventListener("resize", this.handleResize)
-  }
-
-  handleResize = () => {
-    if (window.innerWidth <= 790) {
-      this.setState({
-        mobile: true
-      })
-    } else {
-      this.setState({
-        mobile: false
-      })
-    }
-  }
-
-  state = {
-    mobile: false
-  }
-
   getCourses = () => {
     const classes = this.props.classes
     const { t } = this.props
@@ -81,6 +66,7 @@ class Courses extends Component {
           <ExpandableCourse
             course={this.props.courses[i]}
             key={"expandable" + Math.random()}
+            mobile={this.props.mobile}
           />
         )
       } else {
@@ -88,7 +74,9 @@ class Courses extends Component {
           <div key={this.props.courses[i].crn + i + Math.random()}>
             <div style={{ marginTop: "1em" }}>
               <Card
-                className={classes.card}
+                className={
+                  this.props.mobile ? classes.cardMobile : classes.card
+                }
                 key={this.props.courses[i].crn + i + Math.random()}
               >
                 <CardHeader
@@ -153,27 +141,16 @@ class Courses extends Component {
   }
 
   render() {
+    console.log(this.props.mobile)
     if (this.props.courses === null) {
       return <div />
-    } else if (!this.state.mobile) {
+    } else {
       return (
         <div
           style={{
             display: "flex",
             justifyContent: "space-between",
             flexFlow: "wrap"
-          }}
-        >
-          {this.getCourses()}
-        </div>
-      )
-    } else {
-      return (
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            flexDirection: "column"
           }}
         >
           {this.getCourses()}

--- a/src/components/Courses.js
+++ b/src/components/Courses.js
@@ -13,18 +13,34 @@ import { translate, Interpolate } from "react-i18next"
 import i18n from "./../utils/i18n"
 
 const styleSheet = createStyleSheet("Courses", theme => ({
+  courseContainer: {
+    width: "100%"
+  },
+
+  coursesDiv: {
+    display: "flex",
+    justifyContent: "space-between",
+    flexFlow: "wrap"
+  },
+
+  coursesDivMobile: {
+    display: "flex",
+    alignItems: "center",
+    flexDirection: "column"
+  },
+
   cardDiv: {
     display: "flex",
     flexDirection: "row",
     justifyContent: "space-around"
   },
+
   card: {
     width: 345,
     backgroundColor: "#fafafa"
   },
 
   cardMobile: {
-    width: "264px",
     backgroundColor: "#fafafa"
   },
 
@@ -34,6 +50,7 @@ const styleSheet = createStyleSheet("Courses", theme => ({
   },
 
   classHeader: {
+    height: 65,
     backgroundColor: theme.palette.primary[400]
   },
 
@@ -71,7 +88,10 @@ class Courses extends Component {
         )
       } else {
         elements.push(
-          <div key={this.props.courses[i].crn + i + Math.random()}>
+          <div
+            className={this.props.mobile ? classes.courseContainer : ""}
+            key={this.props.courses[i].crn + i + Math.random()}
+          >
             <div style={{ marginTop: "1em" }}>
               <Card
                 className={
@@ -141,17 +161,15 @@ class Courses extends Component {
   }
 
   render() {
-    console.log(this.props.mobile)
+    const classes = this.props.classes
     if (this.props.courses === null) {
       return <div />
     } else {
       return (
         <div
-          style={{
-            display: "flex",
-            justifyContent: "space-between",
-            flexFlow: "wrap"
-          }}
+          className={
+            this.props.mobile ? classes.coursesDivMobile : classes.coursesDiv
+          }
         >
           {this.getCourses()}
         </div>

--- a/src/components/Courses.js
+++ b/src/components/Courses.js
@@ -32,6 +32,11 @@ const styleSheet = createStyleSheet("Courses", theme => ({
     backgroundColor: theme.palette.primary[400]
   },
 
+  classHeaderSpanDiv: {
+    display: "flex",
+    flexDirection: "column"
+  },
+
   classHeaderSpan: {
     fontWeight: 600,
     color: "rgba(0, 0, 0, 0.75)"
@@ -100,46 +105,26 @@ class Courses extends Component {
                   }
                   key={this.props.courses[i].crn + i + Math.random()}
                   subheader={
-                    <span tabIndex="0" className={classes.classHeaderSpan}>
-                      {this.props.courses[i].subjectCode +
-                        "-" +
-                        this.props.courses[i].subjectNumber +
-                        "-" +
-                        this.props.courses[i].section}
-                    </span>
+                    <div className={classes.classHeaderSpanDiv}>
+                      <span tabIndex="0" className={classes.classHeaderSpan}>
+                        {this.props.courses[i].subjectCode +
+                          "-" +
+                          this.props.courses[i].subjectNumber +
+                          "-" +
+                          this.props.courses[i].section +
+                          "-" +
+                          this.props.courses[i].crn}
+                      </span>
+                      <span tabIndex="0" className={classes.classHeaderSpan}>
+                        {t("credits", {}) + ": " + this.props.courses[i].credit}
+                      </span>
+                    </div>
                   }
                 />
                 <CardContent
                   className={classes.content}
                   key={this.props.courses[i].crn + i + Math.random()}
                 >
-                  <Typography
-                    type="headline"
-                    component="h2"
-                    className={classes.courseTitle}
-                    tabIndex="0"
-                    key={this.props.courses[i].crn + i + Math.random()}
-                  >
-                    {t("section", {}) + ": " + this.props.courses[i].section}
-                  </Typography>
-                  <Typography
-                    type="headline"
-                    component="h2"
-                    className={classes.courseTitle}
-                    tabIndex="0"
-                    key={this.props.courses[i].crn + i + Math.random()}
-                  >
-                    {t("crn", {}) + ": " + this.props.courses[i].crn}
-                  </Typography>
-                  <Typography
-                    type="headline"
-                    component="h2"
-                    className={classes.courseTitle}
-                    tabIndex="0"
-                    key={this.props.courses[i].crn + i + Math.random()}
-                  >
-                    {t("credits", {}) + ": " + this.props.courses[i].credit}
-                  </Typography>
                   <div
                     style={{ marginTop: "1em" }}
                     key={this.props.courses[i].crn + i + Math.random()}

--- a/src/components/CoursesTabs.js
+++ b/src/components/CoursesTabs.js
@@ -34,7 +34,7 @@ const styleSheet = createStyleSheet("BasicTabs", theme => ({
   }
 }))
 
-class BasicTabs extends Component {
+class CoursesTabs extends Component {
   state = {
     index: 0
   }
@@ -86,10 +86,10 @@ class BasicTabs extends Component {
   }
 }
 
-BasicTabs.propTypes = {
+CoursesTabs.propTypes = {
   classes: PropTypes.object.isRequired
 }
 
 export default withStyles(styleSheet)(
-  translate("view", { wait: true })(BasicTabs)
+  translate("view", { wait: true })(CoursesTabs)
 )

--- a/src/components/CoursesTabs.js
+++ b/src/components/CoursesTabs.js
@@ -23,7 +23,7 @@ TabContainer.propTypes = {
 const styleSheet = createStyleSheet("BasicTabs", theme => ({
   root: {
     flexGrow: 1,
-    marginTop: 30
+    marginTop: "1em"
   },
   tabs: {
     height: "0.3em"
@@ -60,7 +60,7 @@ class CoursesTabs extends Component {
             <Tab label={t("grades", {})} tabIndex="0" />
           </Tabs>
         </div>
-        {this.state.index === 0 &&
+        {Object.is(this.state.index, 0) &&
           <TabContainer>
             <div>
               <Courses
@@ -71,13 +71,13 @@ class CoursesTabs extends Component {
               />
             </div>
           </TabContainer>}
-        {this.state.index === 1 &&
+        {Object.is(this.state.index, 1) &&
           <TabContainer>
             <div tabIndex="0">
               <p tabIndex="0">Hello Aaron</p>
             </div>
           </TabContainer>}
-        {this.state.index === 2 &&
+        {Object.is(this.state.index, 2) &&
           <TabContainer>
             <Grades tabIndex="0" courses={this.props.courses} />
           </TabContainer>}

--- a/src/components/ExpandableCourse.js
+++ b/src/components/ExpandableCourse.js
@@ -26,6 +26,11 @@ const styleSheet = createStyleSheet("ExpandableCourse", theme => ({
     backgroundColor: theme.palette.primary[400]
   },
 
+  classHeaderSpanDiv: {
+    display: "flex",
+    flexDirection: "column"
+  },
+
   classHeaderSpan: {
     fontWeight: 600,
     color: "rgba(0, 0, 0, 0.75)"
@@ -63,40 +68,23 @@ class ExpandableCourse extends Component {
               }
               key={this.props.course.crn + 0 + 3}
               subheader={
-                <span tabIndex="0" className={classes.classHeaderSpan}>
-                  {this.props.course.subjectCode +
-                    "-" +
-                    this.props.course.subjectNumber +
-                    "-" +
-                    this.props.course.section}
-                </span>
+                <div className={classes.classHeaderSpanDiv}>
+                  <span tabIndex="0" className={classes.classHeaderSpan}>
+                    {this.props.course.subjectCode +
+                      "-" +
+                      this.props.course.subjectNumber +
+                      "-" +
+                      this.props.course.section +
+                      "-" +
+                      this.props.course.crn}
+                  </span>
+                  <span tabIndex="0" className={classes.classHeaderSpan}>
+                    {t("credits", {}) + ": " + this.props.course.credit}
+                  </span>
+                </div>
               }
             />
             <CardContent className={classes.content}>
-              <Typography
-                type="headline"
-                component="h2"
-                className={classes.courseTitle}
-                tabIndex="0"
-              >
-                {t("section", {}) + ": " + this.props.course.section}
-              </Typography>
-              <Typography
-                type="headline"
-                component="h2"
-                className={classes.courseTitle}
-                tabIndex="0"
-              >
-                {t("crn", {}) + ": " + this.props.course.crn}
-              </Typography>
-              <Typography
-                type="headline"
-                component="h2"
-                className={classes.courseTitle}
-                tabIndex="0"
-              >
-                {t("credits", {}) + ": " + this.props.course.credit}
-              </Typography>
               <div style={{ marginTop: "1em" }}>
                 <Meetings meetings={this.props.course.meetings} />
               </div>

--- a/src/components/ExpandableCourse.js
+++ b/src/components/ExpandableCourse.js
@@ -5,19 +5,21 @@ import Card, { CardHeader, CardActions, CardContent } from "material-ui/Card"
 import Typography from "material-ui/Typography"
 import Instructors from "./Instructors"
 import Meetings from "./Meetings"
-import ExpandableMeetings from "./ExpandableMeetings"
 import CourseDetails from "./CourseDetails"
 import { translate, Interpolate } from "react-i18next"
 import i18n from "./../utils/i18n"
 
 const styleSheet = createStyleSheet("ExpandableCourse", theme => ({
+  courseContainer: {
+    width: "100%"
+  },
+
   card: {
     width: 345,
     backgroundColor: "#fafafa"
   },
 
   cardMobile: {
-    width: "264px",
     backgroundColor: "#fafafa"
   },
 
@@ -28,6 +30,7 @@ const styleSheet = createStyleSheet("ExpandableCourse", theme => ({
   },
 
   classHeader: {
+    height: 65,
     backgroundColor: theme.palette.primary[400]
   },
 
@@ -56,7 +59,7 @@ class ExpandableCourse extends Component {
     const { t } = this.props
     const classes = this.props.classes
     return (
-      <div>
+      <div className={this.props.mobile ? classes.courseContainer : ""}>
         <div style={{ marginTop: "1em" }}>
           <Card
             className={this.props.mobile ? classes.cardMobile : classes.card}

--- a/src/components/ExpandableCourse.js
+++ b/src/components/ExpandableCourse.js
@@ -34,6 +34,12 @@ const styleSheet = createStyleSheet("ExpandableCourse", theme => ({
     backgroundColor: theme.palette.primary[400]
   },
 
+  classHeaderMobile: {
+    height: 65,
+    backgroundColor: theme.palette.primary[400],
+    textAlign: "center"
+  },
+
   classHeaderSpanDiv: {
     display: "flex",
     flexDirection: "column"
@@ -51,6 +57,21 @@ const styleSheet = createStyleSheet("ExpandableCourse", theme => ({
 
   content: {
     paddingTop: 0
+  },
+
+  contentMobile: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center"
+  },
+
+  actions: {
+    display: "flex",
+    justifyContent: "center"
+  },
+
+  infoContainer: {
+    marginLeft: "2em"
   }
 }))
 
@@ -59,13 +80,17 @@ class ExpandableCourse extends Component {
     const { t } = this.props
     const classes = this.props.classes
     return (
-      <div className={this.props.mobile ? classes.courseContainer : ""}>
+      <div className={this.props.mobile ? classes.courseContainer : null}>
         <div style={{ marginTop: "1em" }}>
           <Card
             className={this.props.mobile ? classes.cardMobile : classes.card}
           >
             <CardHeader
-              className={classes.classHeader}
+              className={
+                this.props.mobile
+                  ? classes.classHeaderMobile
+                  : classes.classHeader
+              }
               title={
                 <Typography
                   tabIndex="0"
@@ -94,15 +119,21 @@ class ExpandableCourse extends Component {
                 </div>
               }
             />
-            <CardContent className={classes.content}>
-              <div style={{ marginTop: "1em" }}>
-                <Meetings meetings={this.props.course.meetings} />
-              </div>
-              <div style={{ marginTop: "1em" }}>
-                <Instructors teachers={this.props.course.instructors} />
+            <CardContent
+              className={
+                this.props.mobile ? classes.contentMobile : classes.content
+              }
+            >
+              <div className={this.props.mobile ? classes.infoContainer : null}>
+                <div style={{ marginTop: "1em" }}>
+                  <Meetings meetings={this.props.course.meetings} />
+                </div>
+                <div style={{ marginTop: "1em" }}>
+                  <Instructors teachers={this.props.course.instructors} />
+                </div>
               </div>
             </CardContent>
-            <CardActions>
+            <CardActions className={this.props.mobile ? classes.actions : null}>
               <CourseDetails course={this.props.course} />
             </CardActions>
           </Card>

--- a/src/components/ExpandableCourse.js
+++ b/src/components/ExpandableCourse.js
@@ -16,6 +16,11 @@ const styleSheet = createStyleSheet("ExpandableCourse", theme => ({
     backgroundColor: "#fafafa"
   },
 
+  cardMobile: {
+    width: "264px",
+    backgroundColor: "#fafafa"
+  },
+
   courseTitleH1: {
     fontSize: 16,
     fontWeight: 800,
@@ -53,7 +58,9 @@ class ExpandableCourse extends Component {
     return (
       <div>
         <div style={{ marginTop: "1em" }}>
-          <Card className={classes.card}>
+          <Card
+            className={this.props.mobile ? classes.cardMobile : classes.card}
+          >
             <CardHeader
               className={classes.classHeader}
               title={

--- a/src/components/ExpandableInstructors.js
+++ b/src/components/ExpandableInstructors.js
@@ -19,25 +19,34 @@ const styleSheet = createStyleSheet("ExpandableInstructors", theme => ({
     borderLeftStyle: "solid",
     borderLeftColor: theme.palette.accent[400],
     borderLeftWidth: "0.3em",
-    paddingLeft: "1em"
+    paddingLeft: "1em",
+    fontSize: "14px",
+    fontWeight: 400,
+    fontFamily: "Arimo"
   },
+
   link: {
     marginBottom: 10
   },
+
   teacher: {
     fontSize: 16,
     color: theme.palette.text.primary,
     marginBottom: "0.5em"
   },
+
   expand: {
+    marginTop: "-0.5em",
     transform: "rotate(0deg)",
     transition: theme.transitions.create("transform", {
       duration: theme.transitions.duration.shortest
     })
   },
+
   expandOpen: {
     transform: "rotate(180deg)"
   },
+
   flexGrow: { flex: "1 1 auto" },
   meet: {
     color: "rgba(0, 0, 0, 0.54)"

--- a/src/components/Grades.js
+++ b/src/components/Grades.js
@@ -38,7 +38,8 @@ const styleSheet = createStyleSheet("Grades", theme => ({
   },
 
   content: {
-    paddingTop: 0
+    paddingTop: 0,
+    overflowX: "scroll"
   },
   tableHeader: {
     color: "rgba(0, 0, 0, 1)",

--- a/src/components/Grades.js
+++ b/src/components/Grades.js
@@ -6,7 +6,7 @@ import Table, {
   TableRow
 } from "material-ui/Table"
 import { withStyles, createStyleSheet } from "material-ui/styles"
-import Card, { CardHeader, CardContent, CardMedia } from "material-ui/Card"
+import Card, { CardHeader, CardContent } from "material-ui/Card"
 import Typography from "material-ui/Typography"
 import { getCredits } from "./../api/api"
 import PropTypes from "prop-types"
@@ -65,107 +65,104 @@ class Grades extends Component {
   render() {
     const classes = this.props.classes
     const { t } = this.props
-    if (
-      this.props.courses == null ||
-      this.props.courses == undefined ||
-      this.state.creditsObj == null ||
-      this.state.creditsObj == undefined
-    ) {
+    try {
+      return (
+        <Card className={classes.card}>
+          <CardHeader
+            className={classes.classHeader}
+            title={
+              <Typography
+                tabIndex="0"
+                component="h1"
+                className={classes.classHeaderSpan}
+                style={{ fontSize: "20px" }}
+              >
+                {t("gac", {})}
+              </Typography>
+            }
+          />
+          <CardContent className={classes.content}>
+            <Table>
+              <TableHead>
+                <TableRow className={classes.tableHeader}>
+                  <TableCell className={classes.tableCell} scope="col">
+                    {t("level", {})}
+                  </TableCell>
+                  <TableCell className={classes.tableCell} scope="col">
+                    {t("credits", {})}
+                  </TableCell>
+                  <TableCell className={classes.tableCell} scope="col">
+                    GPA
+                  </TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                <TableRow>
+                  <TableCell>
+                    {this.state.creditsObj[0].level}
+                  </TableCell>
+                  <TableCell>
+                    {this.state.creditsObj[0].credits}
+                  </TableCell>
+                  <TableCell>
+                    {this.state.creditsObj[0].gpa}
+                  </TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+            <Table>
+              <TableHead>
+                <TableRow className={classes.tableHeader}>
+                  <TableCell className={classes.tableCell} scope="col">
+                    {t("course", {})}
+                  </TableCell>
+                  <TableCell className={classes.tableCell} scope="col">
+                    {t("credits", {})}
+                  </TableCell>
+                  <TableCell className={classes.tableCell} scope="col">
+                    {t("grades", {})}
+                  </TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {GradeRow(this.props.courses)}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      )
+    } catch (error) {
       return <div />
     }
-    return (
-      <Card className={classes.card}>
-        <CardHeader
-          className={classes.classHeader}
-          title={
-            <Typography
-              tabIndex="0"
-              component="h1"
-              className={classes.classHeaderSpan}
-              style={{ fontSize: "20px" }}
-            >
-              {t("gac", {})}
-            </Typography>
-          }
-        />
-        <CardContent className={classes.content}>
-          <Table>
-            <TableHead>
-              <TableRow className={classes.tableHeader}>
-                <TableCell className={classes.tableCell} scope="col">
-                  {t("level", {})}
-                </TableCell>
-                <TableCell className={classes.tableCell} scope="col">
-                  {t("credits", {})}
-                </TableCell>
-                <TableCell className={classes.tableCell} scope="col">
-                  GPA
-                </TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              <TableRow>
-                <TableCell>
-                  {this.state.creditsObj[0].level}
-                </TableCell>
-                <TableCell>
-                  {this.state.creditsObj[0].credits}
-                </TableCell>
-                <TableCell>
-                  {this.state.creditsObj[0].gpa}
-                </TableCell>
-              </TableRow>
-            </TableBody>
-          </Table>
-          <Table>
-            <TableHead>
-              <TableRow className={classes.tableHeader}>
-                <TableCell className={classes.tableCell} scope="col">
-                  {t("course", {})}
-                </TableCell>
-                <TableCell className={classes.tableCell} scope="col">
-                  {t("credits", {})}
-                </TableCell>
-                <TableCell className={classes.tableCell} scope="col">
-                  {t("grades", {})}
-                </TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {GradeRow(this.props.courses)}
-            </TableBody>
-          </Table>
-        </CardContent>
-      </Card>
-    )
   }
 }
 
-const GradeRow = obj => {
-  if (Object.is(null, obj) || Object.is(undefined, obj)) {
+const GradeRow = courses => {
+  try {
+    let tableArray = []
+    for (let i = 0; i < courses.length; i++) {
+      let course = courses[i].departmentCode + " - " + courses[i].subjectNumber
+      let credits = courses[i].grade.credit
+      let grade = courses[i].grade.grade
+
+      tableArray.push(
+        <TableRow key={i + Math.random()}>
+          <TableCell>
+            {course}
+          </TableCell>
+          <TableCell>
+            {credits}
+          </TableCell>
+          <TableCell>
+            {grade}
+          </TableCell>
+        </TableRow>
+      )
+    }
+    return tableArray
+  } catch (error) {
     return <TableRow />
   }
-  let tableArray = []
-  for (let i = 0; i < obj.length; i++) {
-    let course = obj[i].departmentCode + " - " + obj[i].subjectNumber
-    let credits = obj[i].grade.credit
-    let grade = obj[i].grade.grade
-
-    tableArray.push(
-      <TableRow>
-        <TableCell>
-          {course}
-        </TableCell>
-        <TableCell>
-          {credits}
-        </TableCell>
-        <TableCell>
-          {grade}
-        </TableCell>
-      </TableRow>
-    )
-  }
-  return tableArray
 }
 
 Grades.propTypes = {

--- a/src/components/Instructors.js
+++ b/src/components/Instructors.js
@@ -15,7 +15,10 @@ const styleSheet = createStyleSheet("Instructors", theme => ({
     borderLeftStyle: "solid",
     borderLeftColor: theme.palette.accent[400],
     borderLeftWidth: "0.3em",
-    paddingLeft: "1em"
+    paddingLeft: "1em",
+    fontSize: "14px",
+    fontWeight: 400,
+    fontFamily: "Arimo"
   },
   link: {
     marginBottom: 10

--- a/src/components/Instructors.js
+++ b/src/components/Instructors.js
@@ -2,12 +2,14 @@ import React, { Component } from "react"
 import PropTypes from "prop-types"
 import { withStyles, createStyleSheet } from "material-ui/styles"
 import Typography from "material-ui/Typography"
+import Divider from "material-ui/Divider"
 import ExpandableInstructors from "./ExpandableInstructors"
 
 const styleSheet = createStyleSheet("Instructors", theme => ({
   button: {
     paddingLeft: 0
   },
+
   links: {
     color: "#3344dd",
     display: "flex",
@@ -20,13 +22,34 @@ const styleSheet = createStyleSheet("Instructors", theme => ({
     fontWeight: 400,
     fontFamily: "Arimo"
   },
+
+  linksMobile: {
+    color: "#3344dd",
+    display: "flex",
+    flexDirection: "column",
+    fontSize: "14px",
+    fontWeight: 400,
+    fontFamily: "Arimo"
+  },
+
+  divider: {
+    height: "2px",
+    marginBottom: "0.2em"
+  },
+
   link: {
     marginBottom: 10
   },
+
   teacher: {
     fontSize: 16,
     color: theme.palette.text.primary,
     marginBottom: "0.5em"
+  },
+
+  teacherMobile: {
+    fontSize: 16,
+    color: theme.palette.text.primary
   }
 }))
 
@@ -54,7 +77,9 @@ class Instructors extends Component {
           <Typography
             type="headline"
             component="h3"
-            className={classes.teacher}
+            className={
+              this.props.mobile ? classes.teacherMobile : classes.teacher
+            }
             tabIndex="0"
             key={this.props.teachers[0].lastName + Math.random()}
           >
@@ -63,7 +88,7 @@ class Instructors extends Component {
               this.props.teachers[0].lastName}
           </Typography>
           <div
-            className={classes.links}
+            className={this.props.mobile ? classes.linksMobile : classes.links}
             key={this.props.teachers[0].lastName + Math.random()}
           >
             <a
@@ -77,6 +102,7 @@ class Instructors extends Component {
               {this.props.teachers[0].office}
             </a>
             <a
+              className={classes.link}
               target="_blank"
               href="mailto:https://oakland.edu"
               tabIndex="0"

--- a/src/components/Meetings.js
+++ b/src/components/Meetings.js
@@ -8,7 +8,10 @@ const styleSheet = createStyleSheet("Meetings", theme => ({
     color: theme.palette.text.primary
   },
   meetLink: {
-    color: "#3344dd"
+    color: "#3344dd",
+    fontSize: "14px",
+    fontWeight: 400,
+    fontFamily: "Arimo"
   }
 }))
 
@@ -21,7 +24,7 @@ class Meetings extends Component {
       return (
         <div key={this.props.meetings[0].endDate + Math.random()}>
           <a
-            type="body2"
+            className={classes.meetLink}
             tabIndex="0"
             target="_blank"
             href="https://oakland.edu"
@@ -39,7 +42,7 @@ class Meetings extends Component {
             tabIndex="0"
             key={this.props.meetings[0].endDate + Math.random()}
           >
-            {this.props.meetings[0].courseType}
+            {this.props.meetings[0].meetDays}
           </Typography>
           <Typography
             type="body2"
@@ -50,6 +53,24 @@ class Meetings extends Component {
             {this.props.meetings[0].startTime +
               " - " +
               this.props.meetings[0].endTime}
+          </Typography>
+          <Typography
+            type="body2"
+            className={classes.meet}
+            tabIndex="0"
+            key={this.props.meetings[0].endDate + Math.random()}
+          >
+            {this.props.meetings[0].startDate +
+              " - " +
+              this.props.meetings[0].endDate}
+          </Typography>
+          <Typography
+            type="body2"
+            className={classes.meet}
+            tabIndex="0"
+            key={this.props.meetings[0].endDate + Math.random()}
+          >
+            {this.props.meetings[0].courseType}
           </Typography>
         </div>
       )

--- a/src/components/TermsMenu.js
+++ b/src/components/TermsMenu.js
@@ -52,9 +52,8 @@ class TermsMenu extends Component {
       return (
         <div style={{ marginTop: "2em" }}>
           <Button
-            accent
+            color="accent"
             raised
-            aria-owns="terms-menu"
             aria-haspopup="true"
             onClick={this.handleClick}
           >

--- a/src/components/TermsMenu.js
+++ b/src/components/TermsMenu.js
@@ -3,6 +3,15 @@
 import React, { Component } from "react"
 import Button from "material-ui/Button"
 import Menu, { MenuItem } from "material-ui/Menu"
+import PropTypes from "prop-types"
+import { withStyles, createStyleSheet } from "material-ui/styles"
+
+const styleSheet = createStyleSheet("TermsMenu", theme => ({
+  mobileTermDiv: {
+    display: "flex",
+    justifyContent: "center"
+  }
+}))
 
 class TermsMenu extends Component {
   componentDidMount() {
@@ -46,11 +55,12 @@ class TermsMenu extends Component {
   }
 
   render() {
+    const classes = this.props.classes
     if (Object.is(this.props.terms, null)) {
       return <div />
     } else {
       return (
-        <div style={{ marginTop: "2em" }}>
+        <div className={this.props.mobile ? classes.mobileTermDiv : ""}>
           <Button
             color="accent"
             raised
@@ -73,4 +83,4 @@ class TermsMenu extends Component {
   }
 }
 
-export default TermsMenu
+export default withStyles(styleSheet)(TermsMenu)

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,0 @@
-body {
-  margin: 0;
-  padding: 0;
-  font-family: sans-serif;
-}

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@ import React from "react"
 import ReactDOM from "react-dom"
 import App from "./App"
 import registerServiceWorker from "./registerServiceWorker"
-import "./index.css"
 import { MuiThemeProvider, createMuiTheme } from "material-ui/styles"
 import createPalette from "material-ui/styles/palette"
 import createTypography from "material-ui/styles/typography"
@@ -62,7 +61,11 @@ const theme = createMuiTheme({
 })
 
 ReactDOM.render(
- <I18nextProvider i18n={i18n}><MuiThemeProvider theme={theme}><App theme={theme} /></MuiThemeProvider></I18nextProvider>,
+  <I18nextProvider i18n={i18n}>
+    <MuiThemeProvider theme={theme}>
+      <App theme={theme} />
+    </MuiThemeProvider>
+  </I18nextProvider>,
   document.getElementById("root")
 )
 registerServiceWorker()

--- a/src/utils/i18n.js
+++ b/src/utils/i18n.js
@@ -15,12 +15,13 @@ i18n.use(Fetch).use(Cache).use(LanguageDetector).init({
     loadPath: "http://localhost:8082/locales/{{lng}}/{{ns}}.json"
   },
   interpolation: {
-    escapeValue: false, // not needed for react!!
     formatSeparator: ",",
     format: function(value, format, lng) {
-      console.log(lng)
-      if (format === "uppercase") return value.toUpperCase()
-      return value
+      if (Object.is(format, "uppercase")) {
+        return value.toUpperCase()
+      } else {
+        return value
+      }
     }
   }
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -140,7 +140,7 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.0.0:
+ansi-styles@^3.0.0, ansi-styles@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.1.0.tgz#09c202d5c917ec23188caa5c9cb9179cd9547750"
   dependencies:
@@ -1247,6 +1247,14 @@ chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chalk@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.0.1.tgz#dbec49436d2ae15f536114e76d14656cdbc0f44d"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
+
 change-emitter@^0.1.2:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/change-emitter/-/change-emitter-0.1.6.tgz#e8b2fe3d7f1ab7d69a32199aff91ea6931409515"
@@ -1977,7 +1985,7 @@ entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-"errno@>=0.1.1 <0.2.0-0", errno@^0.1.3:
+errno@^0.1.3, errno@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.4.tgz#b896e23a9e5e8ba33871fc996abd3635fc9a1c7d"
   dependencies:
@@ -4852,10 +4860,10 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     supports-color "^3.2.3"
 
 postcss@^6.0.1, postcss@^6.x:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.3.tgz#b7f565b3d956fbb8565ca7c1e239d0506e427d8b"
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.4.tgz#573acddf73f42ecb24aa618d40ee3d5a7c04a654"
   dependencies:
-    chalk "^1.1.3"
+    chalk "^2.0.1"
     source-map "^0.5.6"
     supports-color "^4.0.0"
 
@@ -5097,8 +5105,8 @@ react-event-listener@^0.4.5:
     warning "^3.0.0"
 
 react-i18next@^4.1.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-4.5.0.tgz#7be980b3258f326d8bbc4c944d8ab9b9a43aafe9"
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-4.6.1.tgz#27a56ca42fd22431a5ad1a7915aad8d7dae56c03"
   dependencies:
     hoist-non-react-statics "1.2.0"
 
@@ -5886,8 +5894,8 @@ supports-color@^3.1.0, supports-color@^3.1.1, supports-color@^3.1.2, supports-co
     has-flag "^1.0.0"
 
 supports-color@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.0.0.tgz#33a7c680aa512c9d03ef929cacbb974d203d2790"
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.1.0.tgz#92cc14bb3dad8928ca5656c33e19a19f20af5c7a"
   dependencies:
     has-flag "^2.0.0"
 
@@ -6097,8 +6105,8 @@ ua-parser-js@^0.7.9:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.13.tgz#cd9dd2f86493b3f44dbeeef3780fda74c5ee14be"
 
 uglify-js@3.0.x:
-  version "3.0.21"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.0.21.tgz#db66690c7a129a2dbb2417f820ca15c119215a05"
+  version "3.0.22"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.0.22.tgz#0a4d957cf381b38c3f40e9295c442043f04f5805"
   dependencies:
     commander "~2.9.0"
     source-map "~0.5.1"
@@ -6446,11 +6454,11 @@ wordwrap@~1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
 
 worker-farm@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.3.1.tgz#4333112bb49b17aa050b87895ca6b2cacf40e5ff"
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.4.1.tgz#a438bc993a7a7d133bcb6547c95eca7cff4897d8"
   dependencies:
-    errno ">=0.1.1 <0.2.0-0"
-    xtend ">=4.0.0 <4.1.0-0"
+    errno "^0.1.4"
+    xtend "^4.0.1"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"
@@ -6491,7 +6499,7 @@ xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
 
-"xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0:
+xtend@^4.0.0, xtend@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1207,12 +1207,12 @@ caniuse-api@^1.5.2:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30000696"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000696.tgz#e71f5c61e1f96c7a3af4e791ac5db55e11737604"
+  version "1.0.30000697"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000697.tgz#20ce6a9ceeef4ef4a15dc8e80f2e8fb9049e8d77"
 
 caniuse-lite@^1.0.30000669, caniuse-lite@^1.0.30000684:
-  version "1.0.30000696"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000696.tgz#30f2695d2a01a0dfd779a26ab83f4d134b3da5cc"
+  version "1.0.30000697"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000697.tgz#125fb00604b63fbb188db96a667ce2922dcd6cdd"
 
 capture-stack-trace@^1.0.0:
   version "1.0.0"
@@ -1955,8 +1955,8 @@ elliptic@^6.0.0:
     minimalistic-crypto-utils "^1.0.0"
 
 emoji-regex@^6.1.0:
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.4.2.tgz#a30b6fee353d406d96cfb9fa765bdc82897eff6e"
+  version "6.4.3"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.4.3.tgz#6ac2ac58d4b78def5e39b33fcbf395688af3076c"
 
 emojis-list@^2.0.0:
   version "2.1.0"
@@ -1973,8 +1973,8 @@ encoding@^0.1.11:
     iconv-lite "~0.4.13"
 
 enhanced-resolve@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-3.1.0.tgz#9f4b626f577245edcf4b2ad83d86e17f4f421dec"
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-3.3.0.tgz#950964ecc7f0332a42321b673b38dc8ff15535b3"
   dependencies:
     graceful-fs "^4.1.2"
     memory-fs "^0.4.0"
@@ -2776,8 +2776,8 @@ hash-base@^2.0.0:
     inherits "^2.0.1"
 
 hash.js@^1.0.0, hash.js@^1.0.3:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.2.tgz#bf5c887825cfe40b9efde7bf11bd2db26e6bf01b"
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.3.tgz#340dedbe6290187151c1ea1d777a3448935df846"
   dependencies:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.0"
@@ -3976,8 +3976,8 @@ material-ui-icons@^1.0.0-alpha.3:
     recompose "^0.23.5"
 
 material-ui@next:
-  version "1.0.0-alpha.20"
-  resolved "https://registry.yarnpkg.com/material-ui/-/material-ui-1.0.0-alpha.20.tgz#36d4d41e869b9ed0bcacc1dac78a450d2d8ad0b6"
+  version "1.0.0-alpha.21"
+  resolved "https://registry.yarnpkg.com/material-ui/-/material-ui-1.0.0-alpha.21.tgz#c8e73fc253083b79e23aee6ac48b95aaffcae444"
   dependencies:
     babel-runtime "^6.23.0"
     classnames "^2.2.5"
@@ -4860,12 +4860,12 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     supports-color "^3.2.3"
 
 postcss@^6.0.1, postcss@^6.x:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.4.tgz#573acddf73f42ecb24aa618d40ee3d5a7c04a654"
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.5.tgz#efa34f745ca25bd3b3cbd15aa4e03112b8237f3c"
   dependencies:
     chalk "^2.0.1"
     source-map "^0.5.6"
-    supports-color "^4.0.0"
+    supports-color "^4.1.0"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -5893,7 +5893,7 @@ supports-color@^3.1.0, supports-color@^3.1.1, supports-color@^3.1.2, supports-co
   dependencies:
     has-flag "^1.0.0"
 
-supports-color@^4.0.0:
+supports-color@^4.0.0, supports-color@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.1.0.tgz#92cc14bb3dad8928ca5656c33e19a19f20af5c7a"
   dependencies:
@@ -6105,8 +6105,8 @@ ua-parser-js@^0.7.9:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.13.tgz#cd9dd2f86493b3f44dbeeef3780fda74c5ee14be"
 
 uglify-js@3.0.x:
-  version "3.0.22"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.0.22.tgz#0a4d957cf381b38c3f40e9295c442043f04f5805"
+  version "3.0.23"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.0.23.tgz#a58c6b97e6d6763d94dbc265fe8e8c1725e64666"
   dependencies:
     commander "~2.9.0"
     source-map "~0.5.1"


### PR DESCRIPTION
I've moved around some content around in the course card. `Section`, `CRN`, `Credits` have all been moved into the card header. The dialog has been significantly changed. Only the description is now displayed there. Accordingly the button to launch the dialog is simply description now. The courses now will fill width when in the mobile state. What are your thoughts on this? Also, what do you think of centering the text. See the differences below. The first two screenshots are desktop. Last two are mobile. Next, I made the `Grades` table scrollable on the x-axis. Finally, I tested with Axe and I get errors dealing with the color contrast of the `description` button when the dialog is active. I feel like this is a false positive and not really an issue. I'd like you to take a look though. 

<img width="1379" alt="screen shot 2017-06-30 at 10 15 30 pm" src="https://user-images.githubusercontent.com/11354738/27758437-b227b070-5de1-11e7-9029-947b0c3490e5.png">

<img width="1425" alt="screen shot 2017-06-30 at 10 16 57 pm" src="https://user-images.githubusercontent.com/11354738/27758442-df8ebfea-5de1-11e7-9b1e-6f25fa398f16.png">

<img width="724" alt="screen shot 2017-06-30 at 10 18 33 pm" src="https://user-images.githubusercontent.com/11354738/27758456-28fbced4-5de2-11e7-9940-91770339ff8b.png">

<img width="770" alt="screen shot 2017-06-30 at 10 18 12 pm" src="https://user-images.githubusercontent.com/11354738/27758458-369142c2-5de2-11e7-8cb5-5705f7739562.png">
